### PR TITLE
Feat commands copy themselves into history after `Execute`

### DIFF
--- a/src/graphics/drag_and_drop/command/command_history.h
+++ b/src/graphics/drag_and_drop/command/command_history.h
@@ -46,7 +46,11 @@ class CommandHistory {
     }
   }
 
+  /** @note Does nothing if not in the construction of MacroCommand. */
   void endMacroCommand() {
+    if (!IsConstructingMacro_()) {
+      return;
+    }
     auto* macro = macros_under_construction_.top();
     macros_under_construction_.pop();
     if (IsConstructingMacro_()) {

--- a/src/graphics/drag_and_drop/command/drop_command.h
+++ b/src/graphics/drag_and_drop/command/drop_command.h
@@ -23,6 +23,7 @@ class DropCommand : public Command {
     was_executed_ = true;
     RecordPosition_(*curr_mouse_pos);
     command_history_->addCommand(new DropCommand{*this});
+    command_history_->endMacroCommand();
   }
 
   void undo() override {

--- a/src/graphics/drag_and_drop/command/drop_command.h
+++ b/src/graphics/drag_and_drop/command/drop_command.h
@@ -16,12 +16,13 @@ class DropCommand : public Command {
       default; /* shallow copy is allowed since the pointers are shared */
 
   void execute() override {
-    /* so undo-able */
-    was_executed_ = true;
-    RecordPosition_();
-
     auto* curr_mouse_pos = MousePosition::getInstance();
     drag_and_drop_->drop(curr_mouse_pos->getX(), curr_mouse_pos->getY());
+
+    /* so undo-able */
+    was_executed_ = true;
+    RecordPosition_(*curr_mouse_pos);
+    command_history_->addCommand(new DropCommand{*this});
   }
 
   void undo() override {
@@ -48,10 +49,13 @@ class DropCommand : public Command {
   double dropped_x_ = 0;
   double dropped_y_ = 0;
 
-  void RecordPosition_() {
-    auto* curr_mouse_pos = MousePosition::getInstance();
-    dropped_x_ = curr_mouse_pos->getX();
-    dropped_y_ = curr_mouse_pos->getY();
+  /**
+   * @note Can't be const-reference since the getters of MousePosition are
+   * surprisingly non-const.
+   */
+  void RecordPosition_(MousePosition& dropped_pos) {
+    dropped_x_ = dropped_pos.getX();
+    dropped_y_ = dropped_pos.getY();
   }
 };
 

--- a/src/graphics/drag_and_drop/command/grab_command.h
+++ b/src/graphics/drag_and_drop/command/grab_command.h
@@ -16,12 +16,13 @@ class GrabCommand : public Command {
       default; /* shallow copy is allowed since the pointers are shared */
 
   void execute() override {
-    /* so undo-able */
-    was_executed_ = true;
-    RecordPosition_();
-
     auto* curr_mouse_pos = MousePosition::getInstance();
     drag_and_drop_->grab(curr_mouse_pos->getX(), curr_mouse_pos->getY());
+
+    /* so undo-able */
+    was_executed_ = true;
+    RecordPosition_(*curr_mouse_pos);
+    command_history_->addCommand(new GrabCommand{*this});
   }
 
   void undo() override {
@@ -48,10 +49,13 @@ class GrabCommand : public Command {
   double grabbed_x_ = 0;
   double grabbed_y_ = 0;
 
-  void RecordPosition_() {
-    auto* curr_mouse_pos = MousePosition::getInstance();
-    grabbed_x_ = curr_mouse_pos->getX();
-    grabbed_y_ = curr_mouse_pos->getY();
+  /**
+   * @note Can't be const-reference since the getters of MousePosition are
+   * surprisingly non-const.
+   */
+  void RecordPosition_(MousePosition& grabbed_pos) {
+    grabbed_x_ = grabbed_pos.getX();
+    grabbed_y_ = grabbed_pos.getY();
   }
 };
 

--- a/src/graphics/drag_and_drop/command/grab_command.h
+++ b/src/graphics/drag_and_drop/command/grab_command.h
@@ -22,6 +22,7 @@ class GrabCommand : public Command {
     /* so undo-able */
     was_executed_ = true;
     RecordPosition_(*curr_mouse_pos);
+    command_history_->beginMacroCommand();
     command_history_->addCommand(new GrabCommand{*this});
   }
 

--- a/src/graphics/drag_and_drop/command/move_command.h
+++ b/src/graphics/drag_and_drop/command/move_command.h
@@ -16,12 +16,13 @@ class MoveCommand : public Command {
       default; /* shallow copy is allowed since the pointers are shared */
 
   void execute() override {
-    /* so undo-able */
-    was_executed_ = true;
-    RecordPosition_();
-
     auto* curr_mouse_pos = MousePosition::getInstance();
     drag_and_drop_->move(curr_mouse_pos->getX(), curr_mouse_pos->getY());
+
+    /* so undo-able */
+    was_executed_ = true;
+    RecordPosition_(*curr_mouse_pos);
+    command_history_->addCommand(new MoveCommand{*this});
   }
 
   void undo() override {
@@ -48,10 +49,13 @@ class MoveCommand : public Command {
   double prev_x_ = 0;
   double prev_y_ = 0;
 
-  void RecordPosition_() {
-    auto* curr_mouse_pos = MousePosition::getInstance();
-    prev_x_ = curr_mouse_pos->getX();
-    prev_y_ = curr_mouse_pos->getY();
+  /**
+   * @note Can't be const-reference since the getters of MousePosition are
+   * surprisingly non-const.
+   */
+  void RecordPosition_(MousePosition& prev_pos) {
+    prev_x_ = prev_pos.getX();
+    prev_y_ = prev_pos.getY();
   }
 };
 

--- a/test/graphics/drag_and_drop/command/ut_drop_command.h
+++ b/test/graphics/drag_and_drop/command/ut_drop_command.h
@@ -67,17 +67,35 @@ TEST_F(DropCommandTest,
   ASSERT_NEAR(executed_y, got_y, DELTA);
 }
 
-TEST_F(DropCommandTest, ShouldCopyItselfIntoTheHistoryAfterExecution) {
+TEST_F(DropCommandTest, ExecuteShouldCopyItselfIntoHistoryAndEndMacro) {
   const double executed_x = 10;
   const double executed_y = 20;
   MousePosition::getInstance()->setPos(executed_x, executed_y);
 
+  /* History:
+   *  Macro {
+   *    Drop
+   *  }  // ended by drop
+   *  Mock
+   */
+  history_.beginMacroCommand();
   drop_command_.execute();
+  /* The MockCommand added after execute is critical. If endMacroCommand isn't
+    called, the MockCommand will be inside the macro. */
+  history_.addCommand(new MockCommand{});
 
-  const std::stack<Command*> histories = history_.getHistory();
-  ASSERT_EQ(1, histories.size());
-  auto* latest_command = dynamic_cast<DropCommand*>(histories.top());
-  ASSERT_TRUE(latest_command);
-  ASSERT_NEAR(executed_x, latest_command->getX(), DELTA);
-  ASSERT_NEAR(executed_y, latest_command->getY(), DELTA);
+  std::stack<Command*> histories = history_.getHistory();
+  ASSERT_EQ(2, histories.size());
+  auto* mock = dynamic_cast<MockCommand*>(histories.top());
+  ASSERT_TRUE(mock);
+  histories.pop();
+  { /* make the feeling of levels with block */
+    auto* macro = dynamic_cast<MacroCommand*>(histories.top());
+    ASSERT_TRUE(macro);
+    const std::vector<Command*> latest_commands = macro->getCommands();
+    ASSERT_EQ(1, latest_commands.size());
+    auto* latest = dynamic_cast<DropCommand*>(latest_commands.at(0));
+    ASSERT_NEAR(executed_x, latest->getX(), DELTA);
+    ASSERT_NEAR(executed_y, latest->getY(), DELTA);
+  }
 }

--- a/test/graphics/drag_and_drop/command/ut_drop_command.h
+++ b/test/graphics/drag_and_drop/command/ut_drop_command.h
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <stack>
+
 #include "../../../../src/graphics/drag_and_drop/command/command_history.h"
 #include "../../../../src/graphics/drag_and_drop/command/drop_command.h"
 #include "../../../../src/graphics/drag_and_drop/mouse_position.h"
@@ -63,4 +65,19 @@ TEST_F(DropCommandTest,
 
   ASSERT_NEAR(executed_x, got_x, DELTA);
   ASSERT_NEAR(executed_y, got_y, DELTA);
+}
+
+TEST_F(DropCommandTest, ShouldCopyItselfIntoTheHistoryAfterExecution) {
+  const double executed_x = 10;
+  const double executed_y = 20;
+  MousePosition::getInstance()->setPos(executed_x, executed_y);
+
+  drop_command_.execute();
+
+  const std::stack<Command*> histories = history_.getHistory();
+  ASSERT_EQ(1, histories.size());
+  auto* latest_command = dynamic_cast<DropCommand*>(histories.top());
+  ASSERT_TRUE(latest_command);
+  ASSERT_NEAR(executed_x, latest_command->getX(), DELTA);
+  ASSERT_NEAR(executed_y, latest_command->getY(), DELTA);
 }

--- a/test/graphics/drag_and_drop/command/ut_grab_command.h
+++ b/test/graphics/drag_and_drop/command/ut_grab_command.h
@@ -64,3 +64,18 @@ TEST_F(GrabCommandTest,
   ASSERT_NEAR(executed_x, got_x, DELTA);
   ASSERT_NEAR(executed_y, got_y, DELTA);
 }
+
+TEST_F(GrabCommandTest, ShouldCopyItselfIntoTheHistoryAfterExecution) {
+  const double executed_x = 10;
+  const double executed_y = 20;
+  MousePosition::getInstance()->setPos(executed_x, executed_y);
+
+  grab_command_.execute();
+
+  const std::stack<Command*> histories = history_.getHistory();
+  ASSERT_EQ(1, histories.size());
+  auto* latest_command = dynamic_cast<GrabCommand*>(histories.top());
+  ASSERT_TRUE(latest_command);
+  ASSERT_NEAR(executed_x, latest_command->getX(), DELTA);
+  ASSERT_NEAR(executed_y, latest_command->getY(), DELTA);
+}

--- a/test/graphics/drag_and_drop/command/ut_grab_command.h
+++ b/test/graphics/drag_and_drop/command/ut_grab_command.h
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <stack>
+#include <vector>
+
 #include "../../../../src/graphics/drag_and_drop/command/command_history.h"
 #include "../../../../src/graphics/drag_and_drop/command/grab_command.h"
 #include "../../../../src/graphics/drag_and_drop/mouse_position.h"
@@ -65,7 +68,7 @@ TEST_F(GrabCommandTest,
   ASSERT_NEAR(executed_y, got_y, DELTA);
 }
 
-TEST_F(GrabCommandTest, ShouldCopyItselfIntoTheHistoryAfterExecution) {
+TEST_F(GrabCommandTest, ExecuteShouldBeginMacroAndCopyItselfIntoHistory) {
   const double executed_x = 10;
   const double executed_y = 20;
   MousePosition::getInstance()->setPos(executed_x, executed_y);
@@ -74,8 +77,11 @@ TEST_F(GrabCommandTest, ShouldCopyItselfIntoTheHistoryAfterExecution) {
 
   const std::stack<Command*> histories = history_.getHistory();
   ASSERT_EQ(1, histories.size());
-  auto* latest_command = dynamic_cast<GrabCommand*>(histories.top());
-  ASSERT_TRUE(latest_command);
-  ASSERT_NEAR(executed_x, latest_command->getX(), DELTA);
-  ASSERT_NEAR(executed_y, latest_command->getY(), DELTA);
+  auto* macro = dynamic_cast<MacroCommand*>(histories.top());
+  ASSERT_TRUE(macro);
+  const std::vector<Command*> latest_commands = macro->getCommands();
+  ASSERT_EQ(1, latest_commands.size());
+  auto* latest = dynamic_cast<GrabCommand*>(latest_commands.at(0));
+  ASSERT_NEAR(executed_x, latest->getX(), DELTA);
+  ASSERT_NEAR(executed_y, latest->getY(), DELTA);
 }

--- a/test/graphics/drag_and_drop/command/ut_move_command.h
+++ b/test/graphics/drag_and_drop/command/ut_move_command.h
@@ -67,3 +67,17 @@ TEST_F(MoveCommandTest,
   ASSERT_NEAR(executed_y, got_y, DELTA);
 }
 
+TEST_F(MoveCommandTest, ShouldCopyItselfIntoTheHistoryAfterExecution) {
+  const double executed_x = 10;
+  const double executed_y = 20;
+  MousePosition::getInstance()->setPos(executed_x, executed_y);
+
+  move_command_.execute();
+
+  const std::stack<Command*> histories = history_.getHistory();
+  ASSERT_EQ(1, histories.size());
+  auto* latest_command = dynamic_cast<MoveCommand*>(histories.top());
+  ASSERT_TRUE(latest_command);
+  ASSERT_NEAR(executed_x, latest_command->getX(), DELTA);
+  ASSERT_NEAR(executed_y, latest_command->getY(), DELTA);
+}


### PR DESCRIPTION
- `GrabCommand` begins a `MacroCommand` and adds a copy of itself.
- `MoveCommand` adds a copy of itself.
- `DropCommand` adds a copy of itself and ends a `MacroCommand`.